### PR TITLE
Hugo 0.92対応

### DIFF
--- a/layouts/partials/related-item.html
+++ b/layouts/partials/related-item.html
@@ -7,7 +7,7 @@
 {{- $pageSection := .Section -}}
 
 <!-- e.g. "/dic/ansible/" to "ansible.md" -->
-{{- $pagePath := replaceRE "^[^/]+/" "" .Path }}
+{{- $pagePath := replaceRE "^[^/]+/" "" .File.Path }}
 
 <!-- e.g. "ansible.md" to "ansible" -->
 {{- $pageName := replaceRE "\\.md$" "" $pagePath }}


### PR DESCRIPTION
Pageに対する .Path がdeprecatedになっていたので修正。
https://github.com/gohugoio/hugo/releases/tag/v0.92.0
